### PR TITLE
Don't try to call remote if not present.

### DIFF
--- a/app/assets/javascripts/activeadmin/selectize_input.js
+++ b/app/assets/javascripts/activeadmin/selectize_input.js
@@ -30,7 +30,7 @@
       }
 
       opts['load'] = function (query, callback) {
-        if (!query.length) return callback();
+        if (!query.length || !remote.length) return callback();
         $.ajax({
           url: remote + '?q[' + field_text + '_contains]=' + encodeURIComponent(query),
           type: 'GET',


### PR DESCRIPTION
If I have a vanilla selectize with no remote defined the load function calls window.location.pathname, which was not what I expected.