### PR TITLE
Add support for ActiveAdmin version 3

### DIFF
--- a/activeadmin_selectize.gemspec
+++ b/activeadmin_selectize.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['{app,lib}/**/*', 'LICENSE.txt', 'Rakefile', 'README.md']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activeadmin', '~> 2.0'
+  spec.add_runtime_dependency 'activeadmin', '< 4'
   spec.add_runtime_dependency 'sassc', '~> 2.4'
 end


### PR DESCRIPTION
This gem works fine with AA 3, but it is disallowed by the gemspec. This commit fixes that.